### PR TITLE
Append OS and architecture to binary path

### DIFF
--- a/antibody.zsh
+++ b/antibody.zsh
@@ -6,7 +6,7 @@ ARCHITECTURE="$(uname -m)"
 antibody() {
   antibody_os_arch=${ANTIBODY_DIRECTORY}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}
 
-  if [[ -x "$antibody_os_arch" ]]; then
+  if [[ -a "$antibody_os_arch" ]]; then
     antibody="$antibody_os_arch"
   else
     antibody="${ANTIBODY_DIRECTORY}/bin/antibody"

--- a/antibody.zsh
+++ b/antibody.zsh
@@ -4,14 +4,22 @@ OPERATING_SYSTEM="$(uname -s)"
 ARCHITECTURE="$(uname -m)"
 
 antibody() {
+  antibody_os_arch=${ANTIBODY_BINARIES}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}
+
+  if [[ -x "$antibody_os_arch" ]]; then
+    antibody="$antibody_os_arch"
+  else
+    antibody="${ANTIBODY_BINARIES}/bin/antibody"
+  fi
+
   case "$1" in
   bundle|update)
     while read bundle; do
       source "$bundle" 2&> /tmp/antibody-log
-    done < <( "${ANTIBODY_BINARIES}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}" $@ )
+    done < <( "$antibody" $@ )
     ;;
   *)
-    "${ANTIBODY_BINARIES}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}" $@
+    "$antibody" $@
     ;;
   esac
 }

--- a/antibody.zsh
+++ b/antibody.zsh
@@ -1,15 +1,15 @@
 #!/usr/bin/env zsh
-ANTIBODY_BINARIES="$(dirname $0)"
+ANTIBODY_DIRECTORY="$(dirname $0)"
 OPERATING_SYSTEM="$(uname -s)"
 ARCHITECTURE="$(uname -m)"
 
 antibody() {
-  antibody_os_arch=${ANTIBODY_BINARIES}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}
+  antibody_os_arch=${ANTIBODY_DIRECTORY}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}
 
   if [[ -x "$antibody_os_arch" ]]; then
     antibody="$antibody_os_arch"
   else
-    antibody="${ANTIBODY_BINARIES}/bin/antibody"
+    antibody="${ANTIBODY_DIRECTORY}/bin/antibody"
   fi
 
   case "$1" in

--- a/antibody.zsh
+++ b/antibody.zsh
@@ -1,15 +1,17 @@
 #!/usr/bin/env zsh
 ANTIBODY_BINARIES="$(dirname $0)"
+OPERATING_SYSTEM="$(uname -s)"
+ARCHITECTURE="$(uname -m)"
 
 antibody() {
   case "$1" in
   bundle|update)
     while read bundle; do
       source "$bundle" 2&> /tmp/antibody-log
-    done < <( ${ANTIBODY_BINARIES}/bin/antibody $@ )
+    done < <( "${ANTIBODY_BINARIES}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}" $@ )
     ;;
   *)
-    ${ANTIBODY_BINARIES}/bin/antibody $@
+    "${ANTIBODY_BINARIES}/bin/antibody-${OPERATING_SYSTEM}-${ARCHITECTURE}" $@
     ;;
   esac
 }


### PR DESCRIPTION
I wanted to use Antibody across platforms and keep `antibody.zsh` plus the binaries in my [Configuration](https://github.com/jooize/Configuration) repository and thought this should be a neat way to accomplish that. Haven't thought through whether it makes sense for you to build it into Antibody.

Example: `bin/antibody-Darwin-x86_64`

An alternative approach is directories: `bin/FreeBSD/amd64/antibody`

## Relevant

https://github.com/docker/machine/issues/494
https://github.com/docker/machine/issues/2959