### PR TITLE
Other repos

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -2,6 +2,8 @@ package bundle
 
 import (
 	"io/ioutil"
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -10,14 +12,51 @@ import (
 
 var globs = []string{"*.plugin.zsh", "*.zsh", "*.sh", "*.zsh-theme"}
 
-// Bundle is a git-based bundle/plugin
+// BundleType is an interface for different types of bundles
+type BundleType interface {
+	Folder() string
+	Name() string
+	Download() error
+	Update() error
+}
+
+// Bundle is a plugin to install
 type Bundle struct {
-	git.Repo
+	BundleType
+}
+
+// DirBundle is a bundle for local plugins
+type DirBundle struct {
+	name, folder string
+}
+
+// Folder where the local bundle exists
+func (d DirBundle) Folder() string {
+	return d.folder
+}
+
+// Name of the local bundle
+func (d DirBundle) Name() string {
+	return d.name
+}
+
+// Download simply checks the local bundle exists
+func (d DirBundle) Download() error {
+	_, err := os.Stat(d.folder)
+	return err
+}
+
+// Update is a no-op
+func (d DirBundle) Update() error {
+	return nil
 }
 
 // New creates a new bundle instance
 func New(fullName, folder string) Bundle {
-	return Bundle{git.NewGithubRepo(fullName, folder)}
+	if strings.HasPrefix(fullName, "/") {
+		return Bundle{DirBundle{path.Base(fullName), fullName}}
+	}
+	return Bundle{git.NewGitRepo(fullName, folder)}
 }
 
 // Sourceables returns the list of files that could be sourced

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -13,7 +13,7 @@ import (
 var globs = []string{"*.plugin.zsh", "*.zsh", "*.sh", "*.zsh-theme"}
 
 // BundleType is an interface for different types of bundles
-type BundleType interface {
+type Type interface {
 	Folder() string
 	Name() string
 	Download() error
@@ -22,7 +22,7 @@ type BundleType interface {
 
 // Bundle is a plugin to install
 type Bundle struct {
-	BundleType
+	Type
 }
 
 // DirBundle is a bundle for local plugins

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -12,7 +12,7 @@ import (
 
 var globs = []string{"*.plugin.zsh", "*.zsh", "*.sh", "*.zsh-theme"}
 
-// BundleType is an interface for different types of bundles
+// Type is an interface for different types of bundles
 type Type interface {
 	Folder() string
 	Name() string

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -46,8 +46,10 @@ func List(folder string) []Bundle {
 // Parse a list of bundles, one per line, into a Bundle slice
 func Parse(s, folder string) []Bundle {
 	var bundles []Bundle
-	for _, b := range strings.Split(s, "\n") {
-		if strings.TrimSpace(b) != "" {
+	for _, decl := range strings.Split(s, "\n") {
+		b := strings.Split(decl, "#")[0]
+		b = strings.TrimSpace(b)
+		if b != "" {
 			bundles = append(bundles, New(b, folder))
 		}
 	}

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -66,3 +66,10 @@ func TestParseWithEmptyLines(t *testing.T) {
 	s := "caarlos0/zsh-pg\n\n  \ncaarlos0/zsh-open-pr"
 	assert.Len(t, bundle.Parse(s, home), 2)
 }
+
+func TestParseWithComment(t *testing.T) {
+	home := internal.TempHome()
+	defer os.RemoveAll(home)
+	s := "caarlos0/zsh-pg      # this is a comment"
+	assert.Len(t, bundle.Parse(s, home), 1)
+}

--- a/git/git.go
+++ b/git/git.go
@@ -12,13 +12,29 @@ type Repo struct {
 	url, name, folder string
 }
 
-// NewGithubRepo creates a new Github Repo with the fullName and local folder.
-func NewGithubRepo(fullName, folder string) Repo {
-	return Repo{
-		url:    "https://github.com/" + fullName,
-		name:   fullName,
-		folder: filepath.Join(folder, strings.Replace(fullName, "/", "-", -1)),
+// NewGitRepo creates a new Github Repo with the fullName and local folder.
+func NewGitRepo(fullName, folder string) Repo {
+	repo := Repo{
+		name: fullName,
 	}
+	switch {
+	case strings.HasPrefix(fullName, "http://"):
+		fallthrough
+	case strings.HasPrefix(fullName, "https://"):
+		fallthrough
+	case strings.HasPrefix(fullName, "git://"):
+		fallthrough
+	case strings.HasPrefix(fullName, "ssh://"):
+		fallthrough
+	case strings.HasPrefix(fullName, "git@github.com:"):
+		repo.url = fullName
+	default:
+		repo.url = "https://github.com/" + fullName
+	}
+	f := strings.Replace(repo.url, ":", "-COLON-", -1)
+	f = strings.Replace(f, "/", "-SLASH-", -1)
+	repo.folder = filepath.Join(folder, f)
+	return repo
 }
 
 // Folder where the repo was cloned

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -12,7 +12,7 @@ import (
 func TestClonesRepo(t *testing.T) {
 	home := internal.TempHome()
 	defer os.RemoveAll(home)
-	repo := git.NewGithubRepo("caarlos0/env", home)
+	repo := git.NewGitRepo("caarlos0/env", home)
 	assert.NoError(t, repo.Download())
 	internal.AssertFileCount(t, 1, home)
 }
@@ -20,7 +20,7 @@ func TestClonesRepo(t *testing.T) {
 func TestUpdatesRepo(t *testing.T) {
 	home := internal.TempHome()
 	defer os.RemoveAll(home)
-	repo := git.NewGithubRepo("caarlos0/zsh-pg", home)
+	repo := git.NewGitRepo("caarlos0/zsh-pg", home)
 	assert.NoError(t, repo.Download())
 	assert.NoError(t, repo.Update())
 	internal.AssertFileCount(t, 1, home)
@@ -29,7 +29,7 @@ func TestUpdatesRepo(t *testing.T) {
 func TestCloneDoesNothingIfFolderAlreadyExists(t *testing.T) {
 	home := internal.TempHome()
 	defer os.RemoveAll(home)
-	repo := git.NewGithubRepo("caarlos0/zsh-add-upstream", home)
+	repo := git.NewGitRepo("caarlos0/zsh-add-upstream", home)
 	assert.NoError(t, repo.Download())
 	assert.NoError(t, repo.Download())
 	internal.AssertFileCount(t, 1, home)
@@ -38,7 +38,7 @@ func TestCloneDoesNothingIfFolderAlreadyExists(t *testing.T) {
 func TestClonesUnexistentRepo(t *testing.T) {
 	home := internal.TempHome()
 	defer os.RemoveAll(home)
-	repo := git.NewGithubRepo("doesn-not-exist-really", home)
+	repo := git.NewGitRepo("doesn-not-exist-really", home)
 	assert.Error(t, repo.Download())
 	internal.AssertFileCount(t, 0, home)
 }
@@ -46,7 +46,7 @@ func TestClonesUnexistentRepo(t *testing.T) {
 func TestUpdatesUnexistentRepo(t *testing.T) {
 	home := internal.TempHome()
 	defer os.RemoveAll(home)
-	repo := git.NewGithubRepo("doesn-not-exist-really", home)
+	repo := git.NewGitRepo("doesn-not-exist-really", home)
 	assert.Error(t, repo.Update())
 	internal.AssertFileCount(t, 0, home)
 }
@@ -54,7 +54,7 @@ func TestUpdatesUnexistentRepo(t *testing.T) {
 func TestGetsRepoInfo(t *testing.T) {
 	home := internal.TempHome()
 	defer os.RemoveAll(home)
-	repo := git.NewGithubRepo("caarlos0/zsh-pg", home)
+	repo := git.NewGitRepo("caarlos0/zsh-pg", home)
 	assert.Equal(t, "caarlos0/zsh-pg", repo.Name())
-	assert.Equal(t, home+"caarlos0-zsh-pg", repo.Folder())
+	assert.Equal(t, home+"https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-zsh-pg", repo.Folder())
 }


### PR DESCRIPTION
More like actual antigen in terms of support for multiple repos and local bundles.
If a bundle name starts with "/", then we assume its a local bundle and will use the full path as the location
If a bundle name starts with "http", "https", "git://", "ssh://" or "git@github.com:", then we use it as the URL instead of assuming github.com.
Otherwise, we prepend "https://github.com/" to the bundle name to derive the URL.

Switched to using antigen style (replace "/" with "-SLASH-" and ":" with "-COLON") when naming git checkouts.  This allows for repos of the same name from different repos.