### PR TITLE
fix zsh script that sources bundles not to tie up stdin

### DIFF
--- a/shell/init.go
+++ b/shell/init.go
@@ -11,9 +11,9 @@ ANTIBODY_BINARY="%s"
 antibody() {
 	case "$1" in
 	bundle|update)
-		while read bundle; do
+		while read -u 3 bundle; do
 			source "$bundle" 2&> /tmp/antibody-log
-		done < <( $ANTIBODY_BINARY $@ )
+		done 3< <( $ANTIBODY_BINARY $@ )
 		;;
 	*)
 		$ANTIBODY_BINARY $@


### PR DESCRIPTION
I am using antibody to bundle a ssh-agent script.  Since my keys have a password, I need to have stdin attached when zsh starts up and sources the script file so that it can prompt me for a password.