### PR TITLE
fixed update, list and repo name

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -14,12 +14,20 @@ type Repo struct {
 
 // NewGitRepo creates a new Github Repo with the fullName and local folder.
 func NewGitRepo(fullName, folder string) Repo {
-	url := urlFor(fullName)
+	url := urlFor(folderNameToURL(fullName))
 	return Repo{
-		name:   fullName,
+		name:   repoNameFor(url),
 		url:    url,
 		folder: filepath.Join(folder, urlToFolderName(url)),
 	}
+}
+
+func folderNameToURL(url string) string {
+	return strings.Replace(
+		strings.Replace(
+			url, "-COLON-", ":", -1,
+		), "-SLASH-", "/", -1,
+	)
 }
 
 func urlToFolderName(url string) string {
@@ -47,6 +55,12 @@ func urlFor(s string) string {
 		url = "https://github.com/" + s
 	}
 	return url
+}
+
+func repoNameFor(s string) string {
+	ss := strings.Split(s, "/")
+	size := len(ss)
+	return ss[size-2] + "/" + ss[size-1]
 }
 
 // Folder where the repo was cloned

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/getantibody/antibody/git"
@@ -57,4 +58,23 @@ func TestGetsRepoInfo(t *testing.T) {
 	repo := git.NewGitRepo("caarlos0/zsh-pg", home)
 	assert.Equal(t, "caarlos0/zsh-pg", repo.Name())
 	assert.Equal(t, home+"https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-zsh-pg", repo.Folder())
+}
+
+func TestUpdatesAlreadyClonedURL(t *testing.T) {
+	home := internal.TempHome()
+	defer os.RemoveAll(home)
+	repo := git.NewGitRepo("https://github.com/caarlos0/jvm", home)
+	repo.Download()
+	repo2 := git.NewGitRepo(strings.Replace(repo.Folder(), home, "", -1), home)
+	assert.NoError(t, repo.Update())
+	assert.Equal(t, repo.Folder(), repo2.Folder())
+}
+
+func TestGetsRepoNameFromFolder(t *testing.T) {
+	home := internal.TempHome()
+	defer os.RemoveAll(home)
+	repo := git.NewGitRepo("caarlos0/jvm", home)
+	repo.Download()
+	repo2 := git.NewGitRepo(strings.Replace(repo.Folder(), home, "", -1), home)
+	assert.Equal(t, repo.Name(), repo2.Name())
 }


### PR DESCRIPTION
it was broken for a while I think, this PR fixes:

- `list` command to show the name of the git repos:

Before:

```console
~/Code/Go/src/github.com/getantibody/antibody update-list-name 3s
❯ antibody list
https-COLON--SLASH--SLASH-github.com-SLASH-Tarrasch-SLASH-zsh-bd
https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-jvm
https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-zsh-add-upstream
https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-zsh-git-fetch-merge
https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-zsh-git-sync
https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-zsh-mkc
https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-zsh-open-github-pr
https-COLON--SLASH--SLASH-github.com-SLASH-mafredri-SLASH-zsh-async
https-COLON--SLASH--SLASH-github.com-SLASH-sindresorhus-SLASH-pure
https-COLON--SLASH--SLASH-github.com-SLASH-wbinglee-SLASH-zsh-wakatime
https-COLON--SLASH--SLASH-github.com-SLASH-zsh-users-SLASH-zsh-completions
https-COLON--SLASH--SLASH-github.com-SLASH-zsh-users-SLASH-zsh-history-substring-search
https-COLON--SLASH--SLASH-github.com-SLASH-zsh-users-SLASH-zsh-syntax-highlighting
```

After:

```console
~/Code/Go/src/github.com/getantibody/antibody update-list-name
❯ go run cmd/antibody/main.go list
Tarrasch/zsh-bd
caarlos0/jvm
caarlos0/zsh-add-upstream
caarlos0/zsh-git-fetch-merge
caarlos0/zsh-git-sync
caarlos0/zsh-mkc
caarlos0/zsh-open-github-pr
mafredri/zsh-async
sindresorhus/pure
wbinglee/zsh-wakatime
zsh-users/zsh-completions
zsh-users/zsh-history-substring-search
zsh-users/zsh-syntax-highlighting
```

- fixed `update` command. It was prefixing the folder with the antibody home and screwing everything up, so the folder "never exists".
- added more tests