### PR TITLE
Tweaks: Always return in proper order.

### DIFF
--- a/antibody.go
+++ b/antibody.go
@@ -36,14 +36,18 @@ func (a *Antibody) Bundle() (result string, err error) {
 		l := scanner.Text()
 		g.Go(func() error {
 			l = strings.TrimSpace(l)
-			if l != "" && l[0] != '#' {
-				s, err := bundle.New(a.Home, l).Get()
-				lock.Lock()
-				shs = append(shs, s)
-				lock.Unlock()
-				return err
+
+			if l == "" || l[0] == '#' {
+				return nil
 			}
-			return nil
+
+			s, err := bundle.New(a.Home, l).Get()
+
+			lock.Lock()
+			shs = append(shs, s)
+			lock.Unlock()
+
+			return err
 		})
 	}
 	if err := scanner.Err(); err != nil {

--- a/antibody.go
+++ b/antibody.go
@@ -22,7 +22,7 @@ type Antibody struct {
 	Home string
 }
 
-// Pipeline element
+// Result is a pipeline element messenger object
 type Result struct {
 	idx  int
 	line string

--- a/antibody.go
+++ b/antibody.go
@@ -22,6 +22,7 @@ type Antibody struct {
 	Home string
 }
 
+// Pipeline element
 type Result struct {
 	idx  int
 	line string
@@ -39,7 +40,7 @@ func New(home string, r io.Reader) *Antibody {
 func (a *Antibody) Bundle() (result string, err error) {
 	file := a.r
 
-	input_lines := make(chan Result)
+	inputLines := make(chan Result)
 	results := make(chan Result)
 
 	// I think we need a wait group, not sure.
@@ -52,7 +53,7 @@ func (a *Antibody) Bundle() (result string, err error) {
 			// Decreasing internal counter for wait-group as soon as goroutine finishes
 			defer wg.Done()
 
-			for res := range input_lines {
+			for res := range inputLines {
 				log.Debugf("Bundling: %s", res.line)
 				res.line = strings.TrimSpace(res.line)
 
@@ -83,7 +84,7 @@ func (a *Antibody) Bundle() (result string, err error) {
 			line := scan.Text()
 			line = strings.TrimSpace(line)
 
-			input_lines <- Result{idx, line}
+			inputLines <- Result{idx, line}
 			idx++
 		}
 
@@ -92,7 +93,7 @@ func (a *Antibody) Bundle() (result string, err error) {
 			log.Fatal(err)
 		}
 
-		close(input_lines)
+		close(inputLines)
 
 		log.Debugf("Done reading bundles")
 	}()
@@ -104,19 +105,19 @@ func (a *Antibody) Bundle() (result string, err error) {
 	}()
 
 	// collect
-	var all_results []Result
+	var allResults []Result
 	for res := range results {
-		all_results = append(all_results, res)
+		allResults = append(allResults, res)
 	}
 
 	// sort by original idx
-	slice.Sort(all_results[:], func(i, j int) bool {
-		return all_results[i].idx < all_results[j].idx
+	slice.Sort(allResults[:], func(i, j int) bool {
+		return allResults[i].idx < allResults[j].idx
 	})
 
 	// get values
 	var sources []string
-	for _, res := range all_results {
+	for _, res := range allResults {
 		sources = append(sources, res.line)
 	}
 

--- a/bundle/zsh.go
+++ b/bundle/zsh.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/getantibody/antibody/project"
 )
@@ -16,14 +17,19 @@ func (bundle zshBundle) Get() (result string, err error) {
 	if err := bundle.Project.Download(); err != nil {
 		return result, err
 	}
+
+	var lines []string
 	for _, glob := range zshGlobs {
 		files, _ := filepath.Glob(filepath.Join(bundle.Project.Folder(), glob))
 		if files == nil {
 			continue
 		}
 		for _, file := range files {
-			return "source " + file, err
+			lines = append(lines, "source "+file)
 		}
+
+		return strings.Join(lines, "\n"), err
 	}
+
 	return result, nil
 }

--- a/cmd/antibody/main.go
+++ b/cmd/antibody/main.go
@@ -10,11 +10,7 @@ import (
 
 var version = "master"
 
-// Example format string. Everything except the message has a custom color
-// which is dependent on the log level. Many fields have a custom output
-// formatting too, eg. the time returns the hour down to the milli second.
 var format = logging.MustStringFormatter(
-	//`%{color}%{time:15:04:05.000} [%{module}] %{longfunc}: %{color:reset}%{message} %{color}@%{shortfile} %{color}#%{level}%{color:reset}`,
 	`%{color}%{time:15:04:05.000} %{longfunc}: %{color:bold}%{message} %{color:reset}%{color}@%{shortfile} %{color}#%{level}%{color:reset}`,
 )
 

--- a/cmd/antibody/main.go
+++ b/cmd/antibody/main.go
@@ -4,15 +4,36 @@ import (
 	"os"
 
 	"github.com/getantibody/antibody/cmd/antibody/command"
+	logging "github.com/op/go-logging"
 	"github.com/urfave/cli"
 )
 
 var version = "master"
 
+// Example format string. Everything except the message has a custom color
+// which is dependent on the log level. Many fields have a custom output
+// formatting too, eg. the time returns the hour down to the milli second.
+var format = logging.MustStringFormatter(
+	//`%{color}%{time:15:04:05.000} [%{module}] %{longfunc}: %{color:reset}%{message} %{color}@%{shortfile} %{color}#%{level}%{color:reset}`,
+	`%{color}%{time:15:04:05.000} %{longfunc}: %{color:bold}%{message} %{color:reset}%{color}@%{shortfile} %{color}#%{level}%{color:reset}`,
+)
+
+func init() {
+	// For demo purposes, create two backend for os.Stderr.
+	backend := logging.NewLogBackend(os.Stderr, "", 0)
+	formatter := logging.NewBackendFormatter(backend, format)
+
+	logging.SetBackend(formatter)
+
+	logging.SetLevel(logging.INFO, "")
+}
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "antibody"
 	app.Usage = "A faster and simpler antigen written in Golang"
+	app.Author = "Carlos Alexandro Becker (caarlos0@gmail.com)"
+	app.Version = version
 	app.Commands = []cli.Command{
 		command.Bundle,
 		command.Update,
@@ -20,7 +41,5 @@ func main() {
 		command.Home,
 		command.Init,
 	}
-	app.Version = version
-	app.Author = "Carlos Alexandro Becker (caarlos0@gmail.com)"
 	app.Run(os.Args)
 }

--- a/cmd/antibody/main.go
+++ b/cmd/antibody/main.go
@@ -15,21 +15,20 @@ var format = logging.MustStringFormatter(
 )
 
 func init() {
-	// For demo purposes, create two backend for os.Stderr.
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
 	formatter := logging.NewBackendFormatter(backend, format)
-
 	logging.SetBackend(formatter)
-
 	logging.SetLevel(logging.INFO, "")
 }
 
 func main() {
 	app := cli.NewApp()
+
 	app.Name = "antibody"
 	app.Usage = "A faster and simpler antigen written in Golang"
 	app.Author = "Carlos Alexandro Becker (caarlos0@gmail.com)"
 	app.Version = version
+
 	app.Commands = []cli.Command{
 		command.Bundle,
 		command.Update,
@@ -37,5 +36,20 @@ func main() {
 		command.Home,
 		command.Init,
 	}
+
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "verbose",
+			Usage: "Be more verbose",
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		if c.Bool("verbose") {
+			logging.SetLevel(logging.DEBUG, "")
+		}
+		return nil
+	}
+
 	app.Run(os.Args)
 }

--- a/cmd/shell/init.go
+++ b/cmd/shell/init.go
@@ -7,21 +7,22 @@ import (
 )
 
 const template = `#!/usr/bin/env zsh
-ANTIBODY_BINARY="%s"
+ANTIBODY_BINARY=$'%s'
 antibody() {
-	case "$1" in
-	bundle)
-		source <( $ANTIBODY_BINARY $@ ) 2> /dev/null || $ANTIBODY_BINARY $@
-		;;
-	*)
-		$ANTIBODY_BINARY $@
-		;;
+	case $1 in
+		bundle)
+			source <( command $ANTIBODY_BINARY "$@" )
+			;;
+		*)
+			command $ANTIBODY_BINARY "$@"
+			;;
 	esac
 }
 
 _antibody() {
 	IFS=' ' read -A reply <<< "$(echo "bundle update list home init help")"
 }
+
 compctl -K _antibody antibody
 `
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,26 +1,38 @@
-hash: 1b849d1815febbfc31b88f5b99a606f048b16a021271a2d3519636ab4cdacf40
-updated: 2016-11-27T14:20:54.973758838-02:00
+hash: c0bbd1cf6c0f98488e508e5b1fb5556494fb0c7ed9760ffe7c61e5a191505cea
+updated: 2017-01-30T05:25:16.222714239-08:00
 imports:
+- name: github.com/bradfitz/slice
+  version: d9036e2120b5ddfa53f3ebccd618c4af275f47da
 - name: github.com/caarlos0/gohome
-  version: cbed4b26b0bb75922678d7892fde12dccc05a8b3
+  version: 0e4f2f79d87828650a05dd14571c7773e67de445
 - name: github.com/getantibody/folder
   version: e65aa38ebeb03e6d6e91b90a637f3b7c17e1b6d6
 - name: github.com/kardianos/osext
   version: c2c54e542fb797ad986b31721e1baedf214ca413
+- name: github.com/op/go-logging
+  version: 970db520ece77730c7e4724c61121037378659d9
 - name: github.com/urfave/cli
-  version: d53eb991652b1d438abdd34ce4bfa3ef1539108e
+  version: 347a9884a87374d000eec7e6445a34487c1f4a2b
+- name: go4.org
+  version: 7ce08ca145dbe0e66a127c447b80ee7914f3e4f9
+  subpackages:
+  - reflectutil
 - name: golang.org/x/crypto
-  version: 8e06e8ddd9629eb88639aba897641bff8031f1d3
+  version: a59c127441a8ae2ad9b0fb300ab36a6558bba697
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 6d3beaea10370160dea67f5c9327ed791afd5389
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
 - name: golang.org/x/sync
-  version: 316e794f7b5e3df4e95175a45a5fb8b12f85cb4f
+  version: 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
   subpackages:
   - errgroup
+- name: golang.org/x/sys
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  subpackages:
+  - unix
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,20 +1,18 @@
 package: github.com/getantibody/antibody
 import:
-- package: github.com/getantibody/folder
+- package: github.com/bradfitz/slice
 - package: github.com/caarlos0/gohome
-- package: github.com/urfave/cli
+- package: github.com/getantibody/folder
 - package: github.com/kardianos/osext
+- package: github.com/op/go-logging
+- package: github.com/urfave/cli
 - package: golang.org/x/crypto
   subpackages:
   - ssh/terminal
 - package: golang.org/x/sync
   subpackages:
   - errgroup
-- package: golang.org/x/net
-  subpackages:
-  - context
 testImport:
 - package: github.com/stretchr/testify
-  version: ^1.1.3
   subpackages:
   - assert


### PR DESCRIPTION
Always return in proper order as given.
Also fixed a bug where we don't source all files of a glob type (there can be N plugin.zsh files).

I added logging that I can take out if you want, but I think we need it much more than I've even added here. Properly goes to stderr so it doesn't mess with shell integration.