### PR TITLE
Allow specifying subfolder locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ You can also specify a branch to download, for example,
 `antibody bundle caarlos0/jvm branch:v2` will download the `v2` branch of that
 repository.
 
+You may specify a subfolder if the repo you are bundling contains multiple, for
+example `antibody bundle robbyrussell/oh-my-zsh folder:plugins/aws` will look
+for the bundle files in that specific subfolder.
+
 When you decide to update your bundles, just run `antibody update`: it will
 update all bundles inside the `antibody home` folder.
 

--- a/project/git.go
+++ b/project/git.go
@@ -14,6 +14,7 @@ type gitProject struct {
 	URL     string
 	Version string
 	folder  string
+	inner   string
 }
 
 // NewClonedGit is a git project that was already cloned, so, only Update
@@ -35,11 +36,14 @@ func NewClonedGit(home, folderName string) Project {
 // be downloaded to the provided cwd
 func NewGit(cwd, line string) Project {
 	version := "master"
+	inner := ""
 	parts := strings.Split(line, " ")
 	for _, part := range parts {
 		if strings.HasPrefix(part, "branch:") {
 			version = strings.Replace(part, "branch:", "", -1)
-			break
+		}
+		if strings.HasPrefix(part, "folder:") {
+			inner = strings.Replace(part, "folder:", "", -1)
 		}
 	}
 	repo := parts[0]
@@ -63,6 +67,7 @@ func NewGit(cwd, line string) Project {
 		Version: version,
 		URL:     url,
 		folder:  folder,
+		inner:   inner,
 	}
 }
 
@@ -104,5 +109,5 @@ func branch(folder string) (string, error) {
 }
 
 func (g gitProject) Folder() string {
-	return g.folder
+	return filepath.Join(g.folder, g.inner)
 }

--- a/project/git_test.go
+++ b/project/git_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+    "strings"
 	"testing"
 
 	"github.com/getantibody/antibody/project"
@@ -90,6 +91,20 @@ func TestDownloadFolderNaming(t *testing.T) {
 		home+"/https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-ports",
 		repo.Folder(),
 	)
+}
+
+func TestSubFolder(t *testing.T) {
+    assert := assert.New(t)
+    home := home()
+    repo := project.NewGit(home, "robbyrussell/oh-my-zsh folder:plugins/aws")
+    assert.True(strings.HasSuffix(repo.Folder(), "plugins/aws"))
+}
+
+func TestMultipleSubFolders(t *testing.T) {
+    assert := assert.New(t)
+    home := home()
+    assert.NoError(project.NewGit(home, "robbyrussell/oh-my-zsh folder:plugins/aws").Download())
+    assert.NoError(project.NewGit(home, "robbyrussell/oh-my-zsh folder:plugins/battery").Download())
 }
 
 func home() string {


### PR DESCRIPTION
This adds support for repos that contain multiple plugins divided into individual folders.
Includes test cases to support the behavior.  I'm using oh-my-zsh because it's quick and easy
but any repo containing multiple plugins can be used for tests.