### PR TITLE
Use master branch for Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p align="center">
     <a href="https://github.com/getantibody/antibody/releases/latest"><img alt="Release" src="https://img.shields.io/github/release/getantibody/antibody.svg?style=flat-square"></a>
     <a href="/LICENSE.md"><img alt="Software License" src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square"></a>
-    <a href="https://travis-ci.org/getantibody/antibody"><img alt="Travis" src="https://img.shields.io/travis/getantibody/antibody.svg?style=flat-square"></a>
+    <a href="https://travis-ci.org/getantibody/antibody"><img alt="Travis" src="https://img.shields.io/travis/getantibody/antibody/master.svg?style=flat-square"></a>
     <a href="https://codecov.io/gh/getantibody/antibody"><img alt="Codecov branch" src="https://img.shields.io/codecov/c/github/getantibody/antibody/master.svg?style=flat-square"></a>
     <a href="https://goreportcard.com/report/github.com/getantibody/antibody"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/getantibody/antibody?style=flat-square"></a>
     <a href="http://godoc.org/github.com/getantibody/antibody"><img alt="Go Doc" src="https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square"></a>


### PR DESCRIPTION
Currently the build seems to be failing but it's because of a pull request.

<img width="861" alt="screenshot 2018-02-27 15 12 24" src="https://user-images.githubusercontent.com/853977/36713380-a4cb503c-1bd0-11e8-805f-94b7ac191ffd.png">