### PR TITLE
Set environment variables for use in Termux

### DIFF
--- a/project/git.go
+++ b/project/git.go
@@ -81,7 +81,8 @@ func (g gitProject) Download() error {
 			"-b", g.Version,
 			g.URL,
 			g.folder)
-		cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
+		cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+
 		if bts, err := cmd.CombinedOutput(); err != nil {
 			log.Println("git clone failed for", g.URL, string(bts))
 			return err


### PR DESCRIPTION
Termux uses `LD_PRELOAD` and `LD_LIBRARY_PATH` to get around a few issues with the dynamic linker in Android. The issue with antibody is that in `git.go`, an environment variable is set before calling the git binary. This causes the environment of the git process to contain the `GIT_TERMINAL_PROMPT=0` environment variable only, and git cannot find its shared libs on Termux in Android.

This patch checks to see if LD_LIBRARY_PATH and LD_PRELOAD is set, and if the variable is set, sets those variables.