### PR TITLE
safer install

### DIFF
--- a/www/content/install.md
+++ b/www/content/install.md
@@ -9,7 +9,7 @@ Antibody can be installed through a variety of sources.
 The simplest way is to run:
 
 ```sh
-curl -sL git.io/antibody | sh -s
+sh -c "$(curl -sL git.io/antibody)"
 ```
 
 This will put the binary in `/usr/local/bin/antibody`


### PR DESCRIPTION
`curl -sL git.io/antibody | sh -s` starts `curl` and `sh` at the same time, connecting their inputs and outputs. Irregularities in the timing can be detected and malicious code, not visible when simply downloading the script into a file or buffer or when viewing it in a browser, can be injected.

By using `sh -c "$(curl -sL git.io/antibody)"`, the entire contents of the install script are downloaded before `sh` is run. The shell only starts `sh` when `curl` has exited. Due to this the `sh` call can not be detected.

The functionality of both is same, only the implementation is different.

Source: https://unix.stackexchange.com/a/339276