### PR TITLE
fix: correctly update plugins on specific branches

### DIFF
--- a/project/git.go
+++ b/project/git.go
@@ -22,13 +22,14 @@ type gitProject struct {
 // NewClonedGit is a git project that was already cloned, so, only Update
 // will work here.
 func NewClonedGit(home, folderName string) Project {
-	version, err := branch(folderName)
+	folderPath := filepath.Join(home, folderName)
+	version, err := branch(folderPath)
 	if err != nil {
 		version = "master"
 	}
 	url := folder.ToURL(folderName)
 	return gitProject{
-		folder:  filepath.Join(home, folderName),
+		folder:  folderPath,
 		Version: version,
 		URL:     url,
 	}

--- a/project/git_test.go
+++ b/project/git_test.go
@@ -51,6 +51,22 @@ func TestDownloadAnotherBranch(t *testing.T) {
 	require.NoError(t, project.NewGit(home, "caarlos0/jvm branch:gh-pages").Download())
 }
 
+func TestUpdateAnotherBranch(t *testing.T) {
+	home := home()
+	repo := project.NewGit(home, "caarlos0/jvm branch:gh-pages")
+	require.NoError(t, repo.Download())
+	alreadyClonedRepo := project.NewClonedGit(home, "https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-jvm")
+	require.NoError(t, alreadyClonedRepo.Update())
+}
+
+func TestUpdateExistentLocalRepo(t *testing.T) {
+	home := home()
+	repo := project.NewGit(home, "caarlos0/ports")
+	require.NoError(t, repo.Download())
+	alreadyClonedRepo := project.NewClonedGit(home, "https-COLON--SLASH--SLASH-github.com-SLASH-caarlos0-SLASH-ports")
+	require.NoError(t, alreadyClonedRepo.Update())
+}
+
 func TestUpdateNonExistentLocalRepo(t *testing.T) {
 	home := home()
 	repo := project.NewGit(home, "caarlos0/ports")


### PR DESCRIPTION
Existing plugin folders were not prefixed with their cache/home folder
on "antibody update", leading to a failure in checking their current
branch and falling back to the master branch.

Resolves: #246