### PR TITLE
Add support for Windows msys2/cygwin environment

### DIFF
--- a/bundle/fpath.go
+++ b/bundle/fpath.go
@@ -1,8 +1,7 @@
 package bundle
 
 import (
-	"fmt"
-
+	"github.com/getantibody/antibody/helper"
 	"github.com/getantibody/antibody/project"
 )
 
@@ -14,5 +13,5 @@ func (bundle fpathBundle) Get() (result string, err error) {
 	if err = bundle.Project.Download(); err != nil {
 		return result, err
 	}
-	return fmt.Sprintf("fpath+=( %s )", bundle.Project.Path()), err
+	return helper.ComposeFPath(bundle.Project.Path()), err
 }

--- a/bundle/path.go
+++ b/bundle/path.go
@@ -1,6 +1,9 @@
 package bundle
 
-import "github.com/getantibody/antibody/project"
+import (
+	"github.com/getantibody/antibody/helper"
+	"github.com/getantibody/antibody/project"
+)
 
 type pathBundle struct {
 	Project project.Project
@@ -10,5 +13,5 @@ func (bundle pathBundle) Get() (result string, err error) {
 	if err = bundle.Project.Download(); err != nil {
 		return result, err
 	}
-	return "export PATH=\"" + bundle.Project.Path() + ":$PATH\"", err
+	return helper.ComposeEnvPath(bundle.Project.Path()), err
 }

--- a/bundle/zsh.go
+++ b/bundle/zsh.go
@@ -1,11 +1,11 @@
 package bundle
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/getantibody/antibody/helper"
 	"github.com/getantibody/antibody/project"
 )
 
@@ -24,7 +24,7 @@ func (bundle zshBundle) Get() (result string, err error) {
 	// it is a file, not a folder, so just return it
 	if info.Mode().IsRegular() {
 		// XXX: should we add the parent folder to fpath too?
-		return "source " + bundle.Project.Path(), nil
+		return helper.ComposeSource(bundle.Project.Path()), nil
 	}
 	for _, glob := range []string{"*.plugin.zsh", "*.zsh", "*.sh", "*.zsh-theme"} {
 		files, err := filepath.Glob(filepath.Join(bundle.Project.Path(), glob))
@@ -36,9 +36,9 @@ func (bundle zshBundle) Get() (result string, err error) {
 		}
 		var lines []string
 		for _, file := range files {
-			lines = append(lines, "source "+file)
+			lines = append(lines, helper.ComposeSource(file))
 		}
-		lines = append(lines, fmt.Sprintf("fpath+=( %s )", bundle.Project.Path()))
+		lines = append(lines, helper.ComposeFPath(bundle.Project.Path()))
 		return strings.Join(lines, "\n"), err
 	}
 

--- a/helper/compose.go
+++ b/helper/compose.go
@@ -1,0 +1,21 @@
+package helper
+
+import (
+	"fmt"
+)
+
+//ComposeSource compose source command to output
+func ComposeSource(file string) string {
+	return "source " + ConvertToUnixPath(file)
+
+}
+
+//ComposeFPath compose fpath command to output
+func ComposeFPath(path string) string {
+	return fmt.Sprintf("fpath+=( %s )", ConvertToUnixPath(path))
+}
+
+//ComposeEnvPath compose env path command to output
+func ComposeEnvPath(path string) string {
+	return "export PATH=\"" + ConvertToUnixPath(path) + ":$PATH\""
+}

--- a/helper/compose_test.go
+++ b/helper/compose_test.go
@@ -1,0 +1,26 @@
+package helper
+
+import "testing"
+
+func TestComposeSource(t *testing.T) {
+	out := ComposeSource("/path/to/script.zsh")
+	want := "source /path/to/script.zsh"
+	if out != want {
+		t.Fatalf("test compose source: want: %q,got: %q", want, out)
+	}
+}
+func TestComposeFPath(t *testing.T) {
+	out := ComposeFPath("/path/to/fpath")
+	want := "fpath+=( /path/to/fpath )"
+	if out != want {
+		t.Fatalf("test compose fpath: want: %q,got: %q", want, out)
+	}
+}
+
+func TestComposeEnvPath(t *testing.T) {
+	out := ComposeEnvPath("/path/to/bin")
+	want := "export PATH=\"/path/to/bin:$PATH\""
+	if out != want {
+		t.Fatalf("test compose envpath: want:%q,got: %q", want, out)
+	}
+}

--- a/helper/unixPath.go
+++ b/helper/unixPath.go
@@ -1,0 +1,23 @@
+package helper
+
+import (
+	"log"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+//ConvertToUnixPath on Windows convert path to Unix style, use cygpath.exe provided by msys2/cygwin
+//On other OS do nothing
+//Windows native program unable access files through converted path.
+//Call this function only when intend to compose an output for other program(such as zsh) use.
+func ConvertToUnixPath(path string) string {
+	if runtime.GOOS == "windows" {
+		out, err := exec.Command("cygpath.exe", path).Output()
+		if err != nil {
+			log.Fatalf("Error: Unable convert Windows path to unix: %v", err)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	return path
+}

--- a/helper/unixPath_test.go
+++ b/helper/unixPath_test.go
@@ -1,0 +1,16 @@
+package helper
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestConvertToUnixPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		out := ConvertToUnixPath("C:/Windows/")
+		want := "/c/Windows/"
+		if out != want {
+			t.Fatalf("test convert to unix path : incorrect result: want: %q ,got: %q", want, out)
+		}
+	}
+}

--- a/shell/init.go
+++ b/shell/init.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"os"
 	"text/template"
+
+	"github.com/getantibody/antibody/helper"
 )
 
 const tmpl = `#!/usr/bin/env zsh
@@ -26,7 +28,7 @@ compctl -K _antibody antibody
 
 // Init returns the shell that should be loaded to antibody to work correctly.
 func Init() (string, error) {
-	executable, err := os.Executable()
+	executable, err := unixExecutable()
 	if err != nil {
 		return "", err
 	}
@@ -34,4 +36,12 @@ func Init() (string, error) {
 	var out bytes.Buffer
 	err = template.Execute(&out, executable)
 	return out.String(), err
+}
+
+func unixExecutable() (string, error) {
+	osPath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return helper.ConvertToUnixPath(osPath), nil
 }


### PR DESCRIPTION
fix #176 
"cygpath.exe" is a useful tool shipped with msys2/cygwin environment to resolve path easily.

go program is native Windows program and it use Windows native path to access filesystem.
zsh zsh is running inside msys2/cygwin and is not native to Windows that it need to access file through unix style path.

Therefore, just wrap any path string output to bundled script(for zsh to execute) in wrapper function, on Windows it call cygpath.exe convert path to unix style, on other OS it do nothing.

Tested on my msys2-mingw64 environment, it worked as fluent as other OS, without any specific settings or environment variable required.