### PR TITLE
chore: removes extra `<` char from readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,21 @@
   <h3 align="center">Antibody</h3>
   <p align="center">The fastest shell plugin manager.</p>
   <p align="center">
-    <a href="/LICENSE.md"><img alt="Software License" src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square"></a>
-    <a href="https://travis-ci.org/getantibody/antibody"><img alt="Travis" src="https://img.shields.io/travis/getantibody/antibody/master.svg?style=flat-square"></a>
-    <a href="https://codecov.io/gh/getantibody/antibody"><img alt="Codecov branch" src="https://img.shields.io/codecov/c/github/getantibody/antibody/master.svg?style=flat-square"></a>
-    <a href="https://goreportcard.com/report/github.com/getantibody/antibody"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/getantibody/antibody?style=flat-square"></a>
-    <a href="http://godoc.org/github.com/getantibody/antibody"><img alt="Go Doc" src="https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square"></a>>
+    <a href="/LICENSE.md">
+      <img alt="Software License" src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square">
+    </a>
+    <a href="https://travis-ci.org/getantibody/antibody">
+       <img alt="Travis" src="https://img.shields.io/travis/getantibody/antibody/master.svg?style=flat-square">
+    </a>
+    <a href="https://codecov.io/gh/getantibody/antibody">
+      <img alt="Codecov branch" src="https://img.shields.io/codecov/c/github/getantibody/antibody/master.svg?style=flat-square">
+    </a>
+    <a href="https://goreportcard.com/report/github.com/getantibody/antibody">
+      <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/getantibody/antibody?style=flat-square">
+    </a>
+    <a href="http://godoc.org/github.com/getantibody/antibody">
+      <img alt="Go Doc" src="https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square">
+    </a>
   </p>
 </p>
 


### PR DESCRIPTION
That's a pretty simple change. Just removes extra `<` char and adds indentation to HTML at the top of the `README.md` file. 