### PR TITLE
Fix assumed "master" as default branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ cover: test
 
 # Run all the linters
 lint:
-	./bin/golangci-lint run --disable godox --disable wsl --disable gomnd --disable testpackage --disable gofumpt --disable godot --enable-all ./...
+	./bin/golangci-lint run --disable godox --disable wsl --disable gomnd --disable testpackage --disable gofumpt --disable godot --disable nlreturn --enable-all ./...
 .PHONY: lint
 
 # Run all the tests and code checks

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Documentation can be found at https://getantibody.github.io
 - @davidkna's [dotfiles](https://github.com/davidkna/dotfiles);
 - @sobolevn's [dotfiles](https://github.com/sobolevn/dotfiles);
 - @jesseleite's [dotfiles](https://github.com/jesseleite/dotfiles);
+- @mattmc3's [dotfiles](https://github.com/mattmc3/zdotdir/tree/antibody)
 - and probably [many others](https://github.com/search?q=antibody&type=Code);
 
 ## Thanks

--- a/project/git_test.go
+++ b/project/git_test.go
@@ -36,7 +36,7 @@ func TestDownloadAllKinds(t *testing.T) {
 
 func TestDownloadSubmodules(t *testing.T) {
 	var home = home()
-	var proj = NewGit(home, "fribmendes/geometry")
+	var proj = NewGit(home, "fribmendes/geometry branch:master")
 	var module = filepath.Join(proj.Path(), "lib/zsh-async")
 	require.NoError(t, proj.Download())
 	require.NoError(t, proj.Update())


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

**If applied, this commit will...**
This commit addresses issue #369, which describes antibody's default behavior of assuming the "master" branch is the branch desired instead of taking whatever default branch the repo maintainer specifies. Now, instead of hard coding "master", if no branch is specified then `git clone` and `git pull` will not specify a branch either. 

**Why is this change being made?**
GitHub is moving towards naming the new default branch "main". This will break antibody without this fix.

**Possible regressions to note**
- IF a repo happens to have a "master" branch that is not its default, some users may experience a breaking change when antibody pulls that plugin since antibody previously ignored the repo default branch. This seems low risk given that the repo maintainer probably changed the default branch for a reason.