### PR TITLE
Add option to suppress submodules (#366)

### DIFF
--- a/project/git.go
+++ b/project/git.go
@@ -32,9 +32,10 @@ func NewClonedGit(home, folderName string) Project {
 	}
 	url := folder.ToURL(folderName)
 	return gitProject{
-		folder:  folderPath,
-		Version: version,
-		URL:     url,
+		folder:     folderPath,
+		Version:    version,
+		Submodules: true,
+		URL:        url,
 	}
 }
 

--- a/project/git_test.go
+++ b/project/git_test.go
@@ -45,6 +45,17 @@ func TestDownloadSubmodules(t *testing.T) {
 	require.True(t, len(files) > 1)
 }
 
+func TestSkipSubmodules(t *testing.T) {
+	var home = home()
+	var proj = NewGit(home, "fribmendes/geometry branch:master submodules:no")
+	var module = filepath.Join(proj.Path(), "lib/zsh-async")
+	require.NoError(t, proj.Download())
+	require.NoError(t, proj.Update())
+	files, err := ioutil.ReadDir(module)
+	require.NoError(t, err)
+	require.True(t, len(files) == 0)
+}
+
 func TestDownloadAnotherBranch(t *testing.T) {
 	home := home()
 	require.NoError(t, NewGit(home, "caarlos0/jvm branch:gh-pages").Download())

--- a/www/content/options.md
+++ b/www/content/options.md
@@ -102,3 +102,15 @@ fpath+=( /Users/carlos/Library/Caches/antibody/https-COLON--SLASH--SLASH-github.
 source /Users/carlos/Library/Caches/antibody/https-COLON--SLASH--SLASH-github.com-SLASH-ohmyzsh-SLASH-ohmyzsh/plugins/asdf/asdf.plugin.zsh
 fpath+=( /Users/carlos/Library/Caches/antibody/https-COLON--SLASH--SLASH-github.com-SLASH-ohmyzsh-SLASH-ohmyzsh/plugins/asdf )
 ```
+
+## Submodules
+
+If a plugin contains submodules, those will automatically be downloaded with the
+bundle. If you don't want a project's submodules, you can suppress them with the
+`submodules:off` option.
+
+Example:
+
+```console
+antibody bundle sorin-ionescu/prezto submodules:off
+```


### PR DESCRIPTION
Add the `submodule:off` option to suppress repos submodules in the bundle. The default is "on", and the docs have been updated.

See issue #366.
