### PR TITLE
Fix: gocritic linting prefers ReplaceAll

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -45,7 +45,7 @@ func New(home, line string) (Bundle, error) {
 func kind(line string) string {
 	for _, part := range strings.Split(line, " ") {
 		if strings.HasPrefix(part, "kind:") {
-			return strings.Replace(part, "kind:", "", -1)
+			return strings.ReplaceAll(part, "kind:", "")
 		}
 	}
 	return "zsh"

--- a/project/git.go
+++ b/project/git.go
@@ -50,10 +50,10 @@ func NewGit(cwd, line string) Project {
 	parts := strings.Split(line, " ")
 	for _, part := range parts {
 		if strings.HasPrefix(part, branchMarker) {
-			version = strings.Replace(part, branchMarker, "", -1)
+			version = strings.ReplaceAll(part, branchMarker, "")
 		}
 		if strings.HasPrefix(part, pathMarker) {
-			inner = strings.Replace(part, pathMarker, "", -1)
+			inner = strings.ReplaceAll(part, pathMarker, "")
 		}
 	}
 	repo := parts[0]
@@ -149,7 +149,7 @@ func commit(folder string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
 	cmd.Dir = folder
 	rev, err := cmd.Output()
-	return strings.Replace(string(rev), "\n", "", -1), err
+	return strings.ReplaceAll(string(rev), "\n", ""), err
 }
 
 func branch(folder string) (string, error) {
@@ -157,7 +157,7 @@ func branch(folder string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	cmd.Dir = folder
 	branch, err := cmd.Output()
-	return strings.Replace(string(branch), "\n", "", -1), err
+	return strings.ReplaceAll(string(branch), "\n", ""), err
 }
 
 func (g gitProject) Path() string {


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

**If applied, this commit will...**
Replace all calls to `strings.Replace` with strings.ReplaceAll when the the final parameter is -1, per the gocritic linter output:

> bundle/bundle.go:48:11: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(part, "kind:", "", -1)` (gocritic)
> 			return strings.Replace(part, "kind:", "", -1)
> 			       ^
> project/git.go:53:14: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(part, branchMarker, "", -1)` (gocritic)
> 			version = strings.Replace(part, branchMarker, "", -1)
> 			          ^
> project/git.go:56:12: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(part, pathMarker, "", -1)` (gocritic)
> 			inner = strings.Replace(part, pathMarker, "", -1)
> 			        ^
> project/git.go:152:9: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(string(rev), "\n", "", -1)` (gocritic)
> 	return strings.Replace(string(rev), "\n", "", -1), err
> 	       ^
> project/git.go:160:9: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(string(branch), "\n", "", -1)` (gocritic)
> 	return strings.Replace(string(branch), "\n", "", -1), err
> 	       ^
> make: *** [lint] Error 1

**Why is this change being made?**

CI broke.

**Provide links to any relevant tickets, URLs or other resources**

https://github.com/go-critic/go-critic/issues/872
