### PR TITLE
docs: updates brew install command for installing on macOS

### DIFF
--- a/www/content/install.md
+++ b/www/content/install.md
@@ -17,7 +17,7 @@ This will put the binary in `/usr/local/bin/antibody`
 You can also use homebrew (on macOS):
 
 ```sh
-brew install getantibody/tap/antibody
+brew install antibody
 ```
 
 Or even using [AUR](https://aur.archlinux.org/packages/antibody/) on Arch Linux.


### PR DESCRIPTION
```
marshall@marshall-mbp ~ % brew install getantibody/tap/antibody
==> Tapping getantibody/tap
Cloning into '/usr/local/Homebrew/Library/Taps/getantibody/homebrew-tap'...
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 361 (delta 5), reused 0 (delta 0), pack-reused 337
Receiving objects: 100% (361/361), 43.22 KiB | 7.20 MiB/s, done.
Resolving deltas: 100% (99/99), done.
Tapped 1 formula (27 files, 78.5KB).
Error: No available formula or cask with the name "getantibody/tap/antibody".
==> Searching for similarly named formulae...
This similarly named formula was found:
antibody
To install it, run:
  brew install antibody
marshall@marshall-mbp ~ % brew install antibody
==> Downloading https://homebrew.bintray.com/bottles/antibody-6.1.1.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/572351da6247daf6bf29afbdcc8ff10c4fe47e9e413c2ae0df0dd249e855599d?response-content-disposition=attachment%3Bfilename%3D%22antibody-6.1.1.catalina.bottle.tar.gz%22&Policy=eyJTdGF0ZW1lbnQiOiBbeyJS
######################################################################## 100.0%
==> Pouring antibody-6.1.1.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/antibody/6.1.1: 5 files, 4.4MB
```
