### PR TITLE
build(Makefile): set correct version for binary. add clean target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ SOURCE_FILES?=./...
 TEST_PATTERN?=.
 TEST_OPTIONS?=-v
 
+TAG := $(shell git describe --always --tags --abbrev=0 | tr -d "[v\r\n]")
+COMMIT := $(shell git rev-parse --short HEAD| tr -d "[ \r\n\']")
+
 export PATH := ./bin:$(PATH)
 export GO111MODULE := on
 
@@ -33,8 +36,12 @@ ci: build test lint
 
 # Build a beta version
 build:
-	go build
+	go build -ldflags="-s -w -X main.version=v$(TAG)-$(COMMIT)" -o antibody .
 .PHONY: build
+
+clean:
+	rm -f ./antibody
+.PHONY: clean
 
 # gofmt and goimports all go files
 fmt:


### PR DESCRIPTION

<!-- If applied, this commit will... -->

this commit will set the correct app version to the latest tag name when you run `make` or `make build`, not the default `dev`, this is not good.

for example the latest tag is `v6.1.1` and we are at commit hash `49e9319`, `make build` will auto set the version to `v6.1.1-49e9319`

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
